### PR TITLE
EraValBurned always increasing bug fix

### DIFF
--- a/staking/src/lib.rs
+++ b/staking/src/lib.rs
@@ -2866,6 +2866,9 @@ impl<T: Trait> Module<T> {
 
 			// Set ending era reward.
 			<ErasValidatorReward<T>>::insert(&active_era.index, validator_payout);
+			
+			let zero: MultiCurrencyBalanceOf<T> = 0u32.into();
+			EraValBurned::<T>::put(zero);
 		}
 	}
 

--- a/staking/src/tests.rs
+++ b/staking/src/tests.rs
@@ -170,6 +170,20 @@ fn change_controller_works() {
 }
 
 #[test]
+fn notify_val_burned_should_work() {
+	ExtBuilder::default().nominate(true).build_and_execute(|| {
+		<Module<Test>>::notify_val_burned(1000);
+		<Module<Test>>::notify_val_burned(2000);
+		assert_eq!(<Staking as crate::Store>::EraValBurned::get(), 3000);
+		<Module<Test>>::end_era(ActiveEraInfo {
+			index: 0,
+			start: Some(1),
+		}, 0);
+		assert_eq!(<Staking as crate::Store>::EraValBurned::get(), 0);
+	});
+}
+
+#[test]
 fn rewards_should_work() {
 	// should check that:
 	// * rewards get recorded per session


### PR DESCRIPTION
Fixes the ever increasing reward. Instead it should be reset to zero every era.