### PR TITLE
Make ValBurnedNotifier implementation generic with respect to balance type

### DIFF
--- a/staking/src/lib.rs
+++ b/staking/src/lib.rs
@@ -3226,10 +3226,13 @@ impl<T: Trait> Module<T> {
 
 }
 
-impl<T: Trait> ValBurnedNotifier<MultiCurrencyBalanceOf<T>> for Module<T> {
+impl<T: Trait, A> ValBurnedNotifier<A> for Module<T>
+	where A: AtLeast32BitUnsigned + Copy
+{
 	/// Notify the pallet that this `amount` of VAL token was burned.
-	fn notify_val_burned(amount: MultiCurrencyBalanceOf<T>) {
-		let total_val_burned: MultiCurrencyBalanceOf<T> = EraValBurned::<T>::get() + amount;
+	fn notify_val_burned(amount: A) {
+		let value: u128 = amount.unique_saturated_into();
+		let total_val_burned: MultiCurrencyBalanceOf<T> = EraValBurned::<T>::get() + value.unique_saturated_into();
 		EraValBurned::<T>::put(total_val_burned);
 	}
 }

--- a/staking/src/tests.rs
+++ b/staking/src/tests.rs
@@ -172,8 +172,8 @@ fn change_controller_works() {
 #[test]
 fn notify_val_burned_should_work() {
 	ExtBuilder::default().nominate(true).build_and_execute(|| {
-		<Module<Test>>::notify_val_burned(1000);
-		<Module<Test>>::notify_val_burned(2000);
+		<Module<Test>>::notify_val_burned(1_000_u32);
+		<Module<Test>>::notify_val_burned(2_000_u32);
 		assert_eq!(<Staking as crate::Store>::EraValBurned::get(), 3000);
 		<Module<Test>>::end_era(ActiveEraInfo {
 			index: 0,


### PR DESCRIPTION
Generalize the type parameter for the ValBurnedNotifier trait implemented by the pallet_staking module.

Signed-off-by: Eugene Kovalev <eugene.a.kovalev@gmail.com>