### PR TITLE
Account for unadjusted_fee being a fixed point value when adjusting fees

### DIFF
--- a/transaction-payment/src/lib.rs
+++ b/transaction-payment/src/lib.rs
@@ -411,7 +411,11 @@ where
             let unadjusted_weight_fee = Self::weight_to_fee(weight);
             let multiplier = Self::next_fee_multiplier();
             // final adjusted weight fee.
-            let adjusted_weight_fee = multiplier.saturating_mul_int(unadjusted_weight_fee);
+            let adjusted_weight_fee = unadjusted_weight_fee.saturating_mul(
+                multiplier
+                .saturating_mul_int(1u128)
+                .saturated_into()
+            );
 
             let base_fee = Self::weight_to_fee(T::ExtrinsicBaseWeight::get());
             base_fee


### PR DESCRIPTION
Change order in which the `unadjusted_fee` and the `multiplier` are multiplied avoiding the former being converted to an integer. The multiplier still has to be converted to an integer in order to construct a `Balance` out of it but as long as it doesn't have any fractional part this will work.