### PR TITLE
[PSS-934] Update RewardDestination type

### DIFF
--- a/staking/Cargo.toml
+++ b/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
The polkadot.js/apps expects the `pallet-staking::RewardDestination` enum to have more variants than we have had. Furthermore, the default value for `bond()` extrinsic parameter is hardcoded in js apps as "Staked" - one of the variants not having been supported. Since we can't modify the frontend we should ensure our version of the staking pallet treats the staking rewards destination exactly the way the user originally intended. The same argument goes with the two other variants that have been added to the Substrate version of staking recently and are also present in polkadot.js/apps.